### PR TITLE
Fix the Regex Expression in MIMIC Utils

### DIFF
--- a/tasks/mimic_utils.py
+++ b/tasks/mimic_utils.py
@@ -1,4 +1,5 @@
 import argparse
+from typing import Dict, List, Tuple, Optional
 
 import pandas as pd
 import os
@@ -54,56 +55,122 @@ def filter_notes(notes_df: pd.DataFrame, admissions_df: pd.DataFrame, admission_
 
     return notes_df
 
-
 def _norm_header(s: str) -> str:
-    # normalize header for matching: lowercase, collapse spaces, remove trailing colon
     s = s.strip().lower()
     s = re.sub(r"\s+", " ", s)
     s = s[:-1] if s.endswith(":") else s
     return s
 
-def build_header_map(admission_sections: dict[str, str], extra_variants: dict[str, list[str]] | None = None):
+def build_header_map(admission_sections: Dict[str, str],
+                     extra_variants: Optional[Dict[str, List[str]]] = None) -> Dict[str, str]:
     """
-    admission_sections: {CANON_KEY: "Chief Complaint:"}
-    extra_variants: {CANON_KEY: ["CC:", "CHIEF COMPLAINT", ...]}
-    returns: normalized_header -> CANON_KEY
+    Returns map: normalized_header_text -> canonical_key
     """
     header_map = {}
     for canon_key, header in admission_sections.items():
         header_map[_norm_header(header)] = canon_key
-        header_map[_norm_header(header.rstrip(":"))] = canon_key
 
     if extra_variants:
         for canon_key, variants in extra_variants.items():
             for v in variants:
                 header_map[_norm_header(v)] = canon_key
-                header_map[_norm_header(v.rstrip(":"))] = canon_key
 
     return header_map
 
-def extract_sections(note_text: str, header_map: dict[str, str]) -> dict[str, str]:
-    """
-    Find headers as standalone lines, slice content between successive headers.
-    """
-    header_line_re = re.compile(r"(?m)^(?P<h>[A-Za-z][A-Za-z0-9 /&\-\(\)\[\]]{0,60}?):?\s*$")
 
-    matches = []
+def extract_sections_with_rules(note_text: str,
+                                header_map: Dict[str, str],
+                                require_blankline_for_unknown: bool = True) -> Dict[str, str]:
+    """
+    Strategy:
+    - Find candidate header lines (line-anchored).
+    - Accept a candidate as a boundary if:
+        A) it maps to a target header (in header_map)  -> ALWAYS accept
+        B) else accept only if it looks like a real boundary (e.g. preceded by blank line / 2 newlines)
+           (configurable)
+    - Slice sections from accepted boundary headers to next accepted boundary header.
+    - If the same canonical header appears multiple times, concatenate.
+    """
+
+    # Candidate header = a line that is "Header:" or "Header" with nothing else on the line
+    # (we do NOT match inline like "Chief Complaint: nausea" here; we’ll handle inline targets separately)
+    header_line_re = re.compile(
+        r"(?m)^(?P<h>[A-Za-z][A-Za-z0-9 /&\-\(\)\[\]]{0,60}?):\s*$"
+    )
+
+    candidates: List[Tuple[str, int, int]] = []  # (raw_header, line_start, line_end)
     for m in header_line_re.finditer(note_text):
-        raw = m.group("h")
-        canon = header_map.get(_norm_header(raw))
-        if canon:
-            matches.append((canon, m.start(), m.end()))  # start/end of header line
+        candidates.append((m.group("h"), m.start(), m.end()))
 
-    if not matches:
+    # Helper: check if there are 2 newlines (i.e., blank line) right before the header line
+    # We interpret "two newlines" as: somewhere immediately before line_start we have "\n\n"
+    # ignoring spaces/tabs on the blank line.
+    def preceded_by_blankline(line_start: int) -> bool:
+        prefix = note_text[:line_start]
+        # remove trailing spaces/tabs
+        prefix = re.sub(r"[ \t]+$", "", prefix)
+        return prefix.endswith("\n\n")
+
+    # Accepted boundaries: (canon_key, header_line_start, header_line_end)
+    boundaries: List[Tuple[str, int, int]] = []
+
+    for raw, ls, le in candidates:
+        canon = header_map.get(_norm_header(raw))
+
+        if canon is not None:
+            # target header: accept always (this saves inline-ish formatting like Attending\nChief Complaint)
+            boundaries.append((canon, ls, le))
+        else:
+            # unknown header: accept only if structure strongly suggests a section boundary
+            if not require_blankline_for_unknown:
+                continue
+            if preceded_by_blankline(ls):
+                # We accept unknown boundaries only if they have a blank line before them
+                # (prevents "Body ... \nFakeHeader:\nBody continued" from splitting)
+                boundaries.append((_norm_header(raw), ls, le))  # keep normalized name if you want to store it
+            else:
+                # treat as body text, do nothing
+                pass
+
+    # ALSO handle inline target headers: "Chief Complaint: nausea, vomiting"
+    # This catches cases where the header and its value are on the same line.
+    inline_target_re = re.compile(r"(?m)^(?P<h>[^:\n]{2,60}):\s*(?P<v>.+)$")
+    inline_hits: List[Tuple[str, int, int, str]] = []  # (canon, start, end, value)
+    for m in inline_target_re.finditer(note_text):
+        canon = header_map.get(_norm_header(m.group("h")))
+        if canon:
+            inline_hits.append((canon, m.start(), m.end(), m.group("v").strip()))
+
+    # If we found inline hits, we want them to behave like boundaries too,
+    # but we must be careful not to double-count if the same line was already a boundary.
+    boundary_starts = {b[1] for b in boundaries}
+    for canon, s, e, _ in inline_hits:
+        if s not in boundary_starts:
+            boundaries.append((canon, s, e))
+
+    # Sort boundaries by occurrence
+    boundaries.sort(key=lambda t: t[1])
+
+    if not boundaries:
         return {}
 
-    # De-dupe: if same canon appears multiple times, you can choose first, last, or concat.
-    # Besides: We'll concat with "\n\n" in order to stick to the original structure.
-    out = {}
-    for idx, (canon, h_start, h_end) in enumerate(matches):
+    # Slice content between boundaries
+    out: Dict[str, str] = {}
+    for i, (canon, h_start, h_end) in enumerate(boundaries):
         content_start = h_end
-        content_end = matches[idx + 1][1] if idx + 1 < len(matches) else len(note_text)
+        content_end = boundaries[i + 1][1] if i + 1 < len(boundaries) else len(note_text)
         content = note_text[content_start:content_end].strip()
+
+        # If this boundary came from an inline target ("Header: value"),
+        # the "content" might include that same value already; better to use parsed inline value if available.
+        # We'll overwrite the first line if it matches.
+        # (Simple approach: if inline matched at same start, use its value as prefix.)
+        for c2, s2, e2, val in inline_hits:
+            if c2 == canon and s2 == h_start:
+                # Replace content with the remainder after that line, prefixed by inline value
+                remainder = note_text[e2:content_end].strip()
+                content = (val + ("\n" + remainder if remainder else "")).strip()
+                break
 
         if canon in out and content:
             out[canon] = (out[canon].rstrip() + "\n\n" + content)
@@ -142,9 +209,10 @@ def filter_admission_text(notes_df: pd.DataFrame) -> pd.DataFrame:
         notes_df[key] = ""
 
     for i, x in enumerate(notes_df["TEXT"]):
-        sec = extract_sections(x, header_map)
+        sec = extract_sections_with_rules(x, header_map, require_blankline_for_unknown=True)
         for k, v in sec.items():
-            notes_df.at[i, k] = v
+            if k in admission_sections.keys():
+                notes_df.at[i, k] = v
 
     # filter notes with missing main information
     notes_df = notes_df[(notes_df.CHIEF_COMPLAINT != "") | (notes_df.PRESENT_ILLNESS != "") |

--- a/tasks/mimic_utils.py
+++ b/tasks/mimic_utils.py
@@ -2,6 +2,7 @@ import argparse
 
 import pandas as pd
 import os
+import re
 import csv
 
 
@@ -54,34 +55,96 @@ def filter_notes(notes_df: pd.DataFrame, admissions_df: pd.DataFrame, admission_
     return notes_df
 
 
-def filter_admission_text(notes_df) -> pd.DataFrame:
+def _norm_header(s: str) -> str:
+    # normalize header for matching: lowercase, collapse spaces, remove trailing colon
+    s = s.strip().lower()
+    s = re.sub(r"\s+", " ", s)
+    s = s[:-1] if s.endswith(":") else s
+    return s
+
+def build_header_map(admission_sections: dict[str, str], extra_variants: dict[str, list[str]] | None = None):
     """
-    Filter text information by section and only keep sections that are known on admission time.
+    admission_sections: {CANON_KEY: "Chief Complaint:"}
+    extra_variants: {CANON_KEY: ["CC:", "CHIEF COMPLAINT", ...]}
+    returns: normalized_header -> CANON_KEY
+    """
+    header_map = {}
+    for canon_key, header in admission_sections.items():
+        header_map[_norm_header(header)] = canon_key
+        header_map[_norm_header(header.rstrip(":"))] = canon_key
+
+    if extra_variants:
+        for canon_key, variants in extra_variants.items():
+            for v in variants:
+                header_map[_norm_header(v)] = canon_key
+                header_map[_norm_header(v.rstrip(":"))] = canon_key
+
+    return header_map
+
+def extract_sections(note_text: str, header_map: dict[str, str]) -> dict[str, str]:
+    """
+    Find headers as standalone lines, slice content between successive headers.
+    """
+    header_line_re = re.compile(r"(?m)^(?P<h>[A-Za-z][A-Za-z0-9 /&\-\(\)\[\]]{0,60}?):?\s*$")
+
+    matches = []
+    for m in header_line_re.finditer(note_text):
+        raw = m.group("h")
+        canon = header_map.get(_norm_header(raw))
+        if canon:
+            matches.append((canon, m.start(), m.end()))  # start/end of header line
+
+    if not matches:
+        return {}
+
+    # De-dupe: if same canon appears multiple times, you can choose first, last, or concat.
+    # Besides: We'll concat with "\n\n" in order to stick to the original structure.
+    out = {}
+    for idx, (canon, h_start, h_end) in enumerate(matches):
+        content_start = h_end
+        content_end = matches[idx + 1][1] if idx + 1 < len(matches) else len(note_text)
+        content = note_text[content_start:content_end].strip()
+
+        if canon in out and content:
+            out[canon] = (out[canon].rstrip() + "\n\n" + content)
+        elif content:
+            out[canon] = content
+        else:
+            out.setdefault(canon, "")
+
+    return out
+
+
+def filter_admission_text(notes_df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Extract only the sections of the discharge summary that are known at admission time.
     """
     admission_sections = {
-        "CHIEF_COMPLAINT": "chief complaint:",
-        "PRESENT_ILLNESS": "present illness:",
-        "MEDICAL_HISTORY": "medical history:",
-        "MEDICATION_ADM": "medications on admission:",
-        "ALLERGIES": "allergies:",
-        "PHYSICAL_EXAM": "physical exam:",
-        "FAMILY_HISTORY": "family history:",
-        "SOCIAL_HISTORY": "social history:"
+        "CHIEF_COMPLAINT": "Chief Complaint:",
+        "PRESENT_ILLNESS": "History of Present Illness:",
+        "MEDICAL_HISTORY": "Past Medical History:",
+        "MEDICATION_ADM": "Medications on Admission:",
+        "ALLERGIES": "Allergies:",
+        "PHYSICAL_EXAM": "Physical Exam:",
+        "FAMILY_HISTORY": "Family History:",
+        "SOCIAL_HISTORY": "Social History:"
     }
 
-    # replace linebreak indicators
-    notes_df['TEXT'] = notes_df['TEXT'].str.replace(r"\n", r"\\n")
+    extra_variants = {
+        "PRESENT_ILLNESS": ["Present Illness", "HPI", "History Present Illness"],
+        "MEDICAL_HISTORY": ["PMH", "Medical History"],
+        "MEDICATION_ADM": ["Home Medications", "Medications"],
+    }
 
-    # extract each section by regex
+    header_map = build_header_map(admission_sections, extra_variants)
+
     for key in admission_sections.keys():
-        section = admission_sections[key]
-        notes_df[key] = notes_df.TEXT.str.extract(r'(?i){}(.+?)\\n\\n[^(\\|\d|\.)]+?:'
-                                                  .format(section))
+        notes_df[key] = ""
 
-        notes_df[key] = notes_df[key].str.replace(r'\\n', r' ')
-        notes_df[key] = notes_df[key].str.strip()
-        notes_df[key] = notes_df[key].fillna("")
-        notes_df[notes_df[key].str.startswith("[]")][key] = ""
+    for i, x in enumerate(notes_df["TEXT"]):
+        sec = extract_sections(x, header_map)
+        for k, v in sec.items():
+            notes_df.at[i, k] = v
 
     # filter notes with missing main information
     notes_df = notes_df[(notes_df.CHIEF_COMPLAINT != "") | (notes_df.PRESENT_ILLNESS != "") |


### PR DESCRIPTION
This PR fixes the MIMIC regex problem causing the generation of empty train, test and validation data files. There are some problems addressed in this PR, namely:
- Not all admission notes were written in the exactly same format, for example "PMH" or "Medical History". As exhaustive as it sounds, we need to check for extra variations.
- We need to make sure the search for section headers is case-insensitive, so that we don't end up filtering out "Medical history" when "Medical History" is given as the section header.
- Some sections contain multiple paragraphs so that it seems like there is no clean way to extract the section bodies directly from the regex expressions. Instead, splitting by section headers might be a better idea, assuming the entirety of each admission note is enclosed in sections.

The current fix in two important points:
1. Find the locations of the section headers, matching case-insensitively, and the start of the section bodies. It is overshooting so that we can filter non-headers out later.
2. If the matched "section header" is matched by one of the desired section headers we want to have, it's a section header. Else if it is at least one blank line away from the next section above, it's a section header that we don't want. Else, we would concatenate it to the next desired section above.

I considered these edge cases:

```
# (1) input
"""
Attending: [<deid name>]
Chief Complaint: ...
"""
# (1) output
Chief Complaint: {...}

# (2) input
"""
Medications on Admission:
1. ...
...
4. Humalog ...
Subcutaneous four times a day: Please use sliding scale as directed by MD ... 
5. metoprolol ...
"""
# (2) output
Medications on Admission: {...}
```
